### PR TITLE
Nrh favorites delete

### DIFF
--- a/src/scripts/data/provider.js
+++ b/src/scripts/data/provider.js
@@ -144,7 +144,6 @@ export const sendfavoritePosts = (newFavorited) => {
   })
     .then((res) => res.json())
     .then((res) => {
-      debugger;
       mainContainer.dispatchEvent(new CustomEvent("stateChanged"));
     });
 };

--- a/src/scripts/data/provider.js
+++ b/src/scripts/data/provider.js
@@ -103,24 +103,24 @@ export const sendPost = (post) => {
 };
 export const fetchMessages = () => {
   return fetch(`${API}/messages`)
-  .then((response) => response.json())
-  .then((message) => applicationState.allMessages = message)
-}
+    .then((response) => response.json())
+    .then((message) => (applicationState.allMessages = message));
+};
 
 export const postMessage = (message) => {
   const fetchOptions = {
     method: "POST",
     headers: {
-      "Content-type": "application/json"
+      "Content-type": "application/json",
     },
-    body: JSON.stringify(message)
-  }
+    body: JSON.stringify(message),
+  };
   return fetch(`${API}/messages`, fetchOptions)
-  .then((response) => response.json())
-  .then(() => {
-    mainContainer.dispatchEvent(new CustomEvent("stateChanged"));
-  })
-}
+    .then((response) => response.json())
+    .then(() => {
+      mainContainer.dispatchEvent(new CustomEvent("stateChanged"));
+    });
+};
 
 export const deletePost = (id) => {
   return fetch(`${API}/posts/${id}`, {
@@ -141,9 +141,12 @@ export const sendfavoritePosts = (newFavorited) => {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(newFavorited),
-  }).then(() => {
-    mainContainer.dispatchEvent(new CustomEvent("stateChanged"));
-  });
+  })
+    .then((res) => res.json())
+    .then((res) => {
+      debugger;
+      mainContainer.dispatchEvent(new CustomEvent("stateChanged"));
+    });
 };
 
 export const fetchFavoritePosts = () => {
@@ -153,4 +156,12 @@ export const fetchFavoritePosts = () => {
     .then((userData) => {
       applicationState.userFavorites = userData;
     });
+};
+
+export const deleteFavoritePost = (id) => {
+  return fetch(`${API}/favoritedPosts/${id}`, {
+    method: "DELETE",
+  }).then(() => {
+    mainContainer.dispatchEvent(new CustomEvent("stateChanged"));
+  });
 };

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -11,6 +11,8 @@ import {
   sendfavoritePosts,
   fetchFavoritePosts,
   getFavoritePosts,
+  deleteFavoritePost,
+  getPosts,
 } from "./data/provider.js";
 
 const mainContainer = document.querySelector(".giffygram");
@@ -99,19 +101,23 @@ mainContainer.addEventListener("click", (clickEvent) => {
 
 mainContainer.addEventListener("click", (clickEvent) => {
   if (clickEvent.target.name === "favorite") {
-    let postId = parseInt(clickEvent.target.id);
-    let userId = parseInt(localStorage.getItem("gg_user"));
-    let newFavorited = {
-      userId: userId,
-      postId: postId,
-    };
-    sendfavoritePosts(newFavorited);
-  }
-});
-mainContainer.addEventListener("click", (clickEvent) => {
-  if (clickEvent.target.name === "block") {
-    let id = parseInt(clickEvent.target.id);
-    console.log("Test");
-    deletePost(id);
+    const favoritePosts = getFavoritePosts();
+    const postId = parseInt(clickEvent.target.id);
+    const foundFavePostObject = favoritePosts.find((object) => {
+      if (postId === object.postId) {
+        return true;
+      }
+    });
+    if (foundFavePostObject) {
+      const id = foundFavePostObject.id;
+      deleteFavoritePost(id);
+    } else {
+      const userId = parseInt(localStorage.getItem("gg_user"));
+      const newFavorited = {
+        userId: userId,
+        postId: postId,
+      };
+      sendfavoritePosts(newFavorited);
+    }
   }
 });


### PR DESCRIPTION
#### Changes Made

1. Added deleteFavorite function to provider.js. Added event listener on main.js that listens for a click on the star and checks if it is already favorited from the API. If it is then it unfavorites the pot and deletes the object from the API, if it has not been favorited it adds a new object to the API that shows that relationship.
   ​

#### Steps to Review

1. Checkout this branch locally.
   ```
   git fetch --all
   git checkout nrh-favorites-delete
   ```
2. Open a new Terminal tab (⌘T) and navigate to the server directory.
3. Test app functionality.
  Make a new post and favorite it. Verify that star turns yellow and stays favorited on page refresh. Then unfavorite the post and verify star goes hollow. Verify that it stays hollow on page refresh. 
4. View code file.
   We will review the code verbally with each other. 
